### PR TITLE
Add copy clone github link

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -14,7 +14,9 @@ actions.vimEditURL = () =>
     actions.openLink(url)()
   }, "url")
 
-actions.getURLPath = ({ count = 0, domain = false } = {}) => {
+actions.getURLPath = ({
+  count = 0, domain = false, replace = (path) => path,
+} = {}) => {
   let path = util.getCurrentLocation("pathname").slice(1)
   if (count) {
     path = path.split("/").slice(0, count).join("/")
@@ -22,11 +24,11 @@ actions.getURLPath = ({ count = 0, domain = false } = {}) => {
   if (domain) {
     path = `${util.getCurrentLocation("hostname")}/${path}`
   }
-  return path
+  return replace(path)
 }
 
-actions.copyURLPath = ({ count, domain } = {}) => () =>
-  Clipboard.write(actions.getURLPath({ count, domain }))
+actions.copyURLPath = ({ count, domain, replace } = {}) => () =>
+  Clipboard.write(actions.getURLPath({ count, domain, replace }))
 
 actions.copyOrgLink = () =>
   Clipboard.write(`[[${util.getCurrentLocation("href")}][${document.title}]]`)

--- a/keys.js
+++ b/keys.js
@@ -453,6 +453,11 @@ maps["github.com"] = [
     callback:    actions.copyURLPath({ count: 2 }),
   },
   {
+    alias:       "L",
+    description: "Copy clone Path",
+    callback:    actions.copyURLPath({ count: 2, replace: (path) => `git@github.com:${path}.git` }),
+  },
+  {
     alias:       "Y",
     description: "Copy Project Path (including domain)",
     callback:    actions.copyURLPath({ count: 2, domain: true }),


### PR DESCRIPTION
1. Added `replace` argument to getURLPath, by default it's identity function.
2. Added binding to <space>L
L was an arbitrary choice, because of `y`, `Y` and `c` are already in use

3. Result: git@github.com:b0o/surfingkeys-conf.git

Closes #43 

